### PR TITLE
chore(ci): remove old ci workflow

### DIFF
--- a/.github/workflows/ci-ecr.yml
+++ b/.github/workflows/ci-ecr.yml
@@ -5,10 +5,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
-  
+
 permissions:
   id-token: write
   contents: write


### PR DESCRIPTION
removes old workflow that builds ECR images on PRs, which is blocking forked merges due to auth issues